### PR TITLE
Adds --upgrade flag to the project.json hooks

### DIFF
--- a/project.develop.json
+++ b/project.develop.json
@@ -6,6 +6,6 @@
   "role": "arn:aws:iam::002723143144:role/dev-tx_lambda_function",
   "environment": {},
   "hooks":{
-    "build": "pip install -r requirements.txt -t ."
+    "build": "pip install --upgrade -r requirements.txt -t ."
   }
 }

--- a/project.master.json
+++ b/project.master.json
@@ -6,6 +6,6 @@
   "role": "arn:aws:iam::002723143144:role/tx_lambda_function",
   "environment": {},
   "hooks":{
-    "build": "pip install -r requirements.txt -t ."
+    "build": "pip install --upgrade -r requirements.txt -t ."
   }
 }

--- a/project.test.json.sample
+++ b/project.test.json.sample
@@ -6,6 +6,6 @@
   "role": "arn:aws:iam::581647696645:role/tx_lambda_function",
   "environment": {},
   "hooks":{
-    "build": "pip install git+https://github.com/<username>/tx-manager.git@<branch> -t ."
+    "build": "pip install --upgrade git+https://github.com/<username>/tx-manager.git@<branch> -t ."
   }
 }


### PR DESCRIPTION
Added the --upgrade flag because if you make changes your branch that it points to, and have already ran `apex deploy` before, it won't get changes, using the download from the previous deploy.