### PR TITLE
Feature 542 - Push out latest tx-manager to tx-manager-lambda

### DIFF
--- a/requirements.master.txt
+++ b/requirements.master.txt
@@ -1,2 +1,2 @@
-git+git://github.com/unfoldingword-dev/tx-manager.git@v0.2.2
+git+git://github.com/unfoldingword-dev/tx-manager.git@v0.2.3
 mock==2.0.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(f_name):
 
 setup(
     name="tx-manager-lambda",
-    version="0.2.2",
+    version="0.2.3",
     package_dir={
         'client_callback': 'functions/client_callback',
         'client_webhook': 'functions/client_webhook',

--- a/test-setup.py
+++ b/test-setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="tx-manager-lambda",
-    version="0.2.2",
+    version="0.2.3",
     package_dir={
         'client_callback': 'functions/client_callback',
         'client_webhook': 'functions/client_webhook',


### PR DESCRIPTION
Feature https://github.com/unfoldingWord-dev/door43.org/issues/542 - Push out latest tx-manager to tx-manager-lambda

Update to use new tx-manager version.