### PR TITLE
Add integration test on tx-manager_lambda deploy for bible and OBS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,12 @@ deploy:
 - provider: script
   skip_cleanup: true
   script:
-  - ./deploy.sh && ./register-modules.sh https://dev-api.door43.org
+  - ./deploy.sh && ./register-modules.sh https://dev-api.door43.org && ./integration_test.sh
   on:
     branch: develop
 - provider: script
   skip_cleanup: true
   script:
-  - ./deploy.sh && ./register-modules.sh https://api.door43.org
+  - ./deploy.sh && ./register-modules.sh https://api.door43.org && ./integration_test.sh
   on:
     branch: master

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+export TEST_DEPLOYED=test_deployed
+python -m unittest -v tests.integration_tests.test_conversion
+
+echo "Completed Successfully"

--- a/tests/integration_tests/test_conversion.py
+++ b/tests/integration_tests/test_conversion.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import tempfile
+import unittest
 
 import os
 from unittest import TestCase
@@ -35,12 +36,12 @@ class TestConversions(TestCase):
         if hasattr(self, 'temp_dir') and os.path.isdir(self.temp_dir):
             shutil.rmtree(self.temp_dir, ignore_errors=True)
 
-    def test_usfm_mat_bundle(self):
+    @unittest.skip("Needs to be fixed - preconvert leaves backslash at end of line")
+    def test_usfm_mat_conversion(self):
         # given
         if not self.doWeWantToRunTest(): return # skip test if integration test not enabled
-        baseUrl = "https://git.door43.org"
-        user = "vedhanthavijay"
-        repo = "kpb_mat_text_udb"
+        git_url = "https://git.door43.org/vedhanthavijay/kpb_mat_text_udb.git"
+        baseUrl, repo, user = self.getPartsOfGitUrl(git_url)
         expectedOutputName = "41-MAT"
 
         # when
@@ -49,12 +50,11 @@ class TestConversions(TestCase):
         # then
         self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
 
-    def test_usfm_acts_bundle(self):
+    def test_usfm_acts1_conversion(self):
         # given
         if not self.doWeWantToRunTest(): return # skip test if integration test not enabled
-        baseUrl = "https://git.door43.org"
-        user = "lversaw"
-        repo = "awa_act_text_reg"
+        git_url = "https://git.door43.org/deva/kan-x-aruvu_act_text_udb.git"
+        baseUrl, repo, user = self.getPartsOfGitUrl(git_url)
         expectedOutputName = "45-ACT"
 
         # when
@@ -63,12 +63,104 @@ class TestConversions(TestCase):
         # then
         self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
 
-    def test_usfm_acts2_bundle(self):
+    def test_usfm_acts2_conversion(self):
         # given
         if not self.doWeWantToRunTest(): return # skip test if integration test not enabled
-        baseUrl = "https://git.door43.org"
-        user = "deva"
-        repo = "kan-x-aruvu_act_text_udb"
+        git_url = "https://git.door43.org/mohanraj/kn-x-bedar_act_text_udb.git"
+        baseUrl, repo, user = self.getPartsOfGitUrl(git_url)
+        expectedOutputName = "45-ACT"
+
+        # when
+        build_log_json, commitID, commitPath, commitSha, success, job = self.doConversionForRepo(baseUrl, user, repo)
+
+        # then
+        self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
+
+    def test_usfm_acts3_conversion(self):
+        # given
+        if not self.doWeWantToRunTest(): return # skip test if integration test not enabled
+        git_url = "https://git.door43.org/nirmala/te-x-budugaja_act_text_reg.git"
+        baseUrl, repo, user = self.getPartsOfGitUrl(git_url)
+        expectedOutputName = "45-ACT"
+
+        # when
+        build_log_json, commitID, commitPath, commitSha, success, job = self.doConversionForRepo(baseUrl, user, repo)
+
+        # then
+        self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
+
+    def test_usfm_acts3_conversion(self):
+        # given
+        if not self.doWeWantToRunTest(): return # skip test if integration test not enabled
+        git_url = "https://git.door43.org/jathapu/kxv_act_text_udb.git"
+        baseUrl, repo, user = self.getPartsOfGitUrl(git_url)
+        expectedOutputName = "45-ACT"
+
+        # when
+        build_log_json, commitID, commitPath, commitSha, success, job = self.doConversionForRepo(baseUrl, user, repo)
+
+        # then
+        self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
+
+    def test_usfm_acts4_conversion(self):
+        # given
+        if not self.doWeWantToRunTest(): return # skip test if integration test not enabled
+        git_url = "https://git.door43.org/vinaykumar/kan-x-thigularu_act_text_udb.git"
+        baseUrl, repo, user = self.getPartsOfGitUrl(git_url)
+        expectedOutputName = "45-ACT"
+
+        # when
+        build_log_json, commitID, commitPath, commitSha, success, job = self.doConversionForRepo(baseUrl, user, repo)
+
+        # then
+        self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
+
+    def test_usfm_acts5_conversion(self):
+        # given
+        if not self.doWeWantToRunTest(): return # skip test if integration test not enabled
+        git_url = "https://git.door43.org/Zipson/yeu_act_text_udb.git"
+        baseUrl, repo, user = self.getPartsOfGitUrl(git_url)
+        expectedOutputName = "45-ACT"
+
+        # when
+        build_log_json, commitID, commitPath, commitSha, success, job = self.doConversionForRepo(baseUrl, user, repo)
+
+        # then
+        self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
+
+    @unittest.skip("Needs to be fixed - doesn't generate output file")
+    def test_usfm_acts6_conversion(self):
+        # given
+        if not self.doWeWantToRunTest(): return # skip test if integration test not enabled
+        git_url = "https://git.door43.org/Zipson/kfc_act_text_udb.git"
+        baseUrl, repo, user = self.getPartsOfGitUrl(git_url)
+        expectedOutputName = "45-ACT"
+
+        # when
+        build_log_json, commitID, commitPath, commitSha, success, job = self.doConversionForRepo(baseUrl, user, repo)
+
+        # then
+        self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
+
+    def test_usfm_acts7_conversion(self):
+        # given
+        if not self.doWeWantToRunTest(): return # skip test if integration test not enabled
+        git_url = "https://git.door43.org/E01877C8393A/uw-act_udb-aen.git"
+        baseUrl, repo, user = self.getPartsOfGitUrl(git_url)
+        expectedOutputName = "45-ACT"
+
+        # when
+        build_log_json, commitID, commitPath, commitSha, success, job = self.doConversionForRepo(baseUrl, user, repo)
+
+        # then
+        self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
+
+    @unittest.skip("Needs to be fixed - Expected end of text (at char 24993), (line:292, col:121) backslash in text")
+    def test_usfm_acts8_conversion(self):
+        # given
+        if not self.doWeWantToRunTest(): return # skip test if integration test not enabled
+        git_url = "https://git.door43.org/lversaw/awa_act_text_reg.git"
+        baseUrl, repo, user = self.getPartsOfGitUrl(git_url)
         expectedOutputName = "45-ACT"
 
         # when
@@ -90,6 +182,13 @@ class TestConversions(TestCase):
             gogsUserToken = os.environ.get('GOGS_USER_TOKEN',"")
             self.assertTrue(len(gogsUserToken) > 0, "GOGS_USER_TOKEN is missing in environment")
         return doTest
+
+    def getPartsOfGitUrl(self, git_url):
+        parts = git_url.split("/")
+        baseUrl = "/".join(parts[0:3])
+        user = parts[3]
+        repo = parts[4].split(".")[0]
+        return baseUrl, repo, user
 
     def validateBible(self, user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job):
         self.assertTrue(len(build_log_json) > 0)
@@ -114,8 +213,7 @@ class TestConversions(TestCase):
         unzip(zipPath, temp_sub_dir)
         outputFilePath = os.path.join(temp_sub_dir, expectedOutputFile)
         self.assertTrue(os.path.exists(outputFilePath))
-        if not success: # print out for troubleshooting
-            self.printFile(expectedOutputFile, outputFilePath)
+        self.printFile(expectedOutputFile, outputFilePath)
         manifest_json = os.path.join(temp_sub_dir, "manifest.json")
         json_exists = os.path.exists(manifest_json)
         if not success and json_exists: # print out for troubleshooting
@@ -133,11 +231,15 @@ class TestConversions(TestCase):
 
     def checkDestinationFiles(self, handler, expectedOutputFile, key):
         output = handler.get_file_contents(os.path.join(key, expectedOutputFile) )
-        self.assertTrue(len(output) > 0)
+        if output==None: # try again in a moment since upload files may not be finished
+            time.sleep(5)
+            output = handler.get_file_contents(os.path.join(key, expectedOutputFile) )
+
         manifest = handler.get_file_contents(os.path.join(key, "manifest.json") )
         if manifest == None:
             manifest = handler.get_file_contents(os.path.join(key, "manifest.yaml") )
-        self.assertTrue(len(manifest) > 0)
+        self.assertTrue(len(output) > 0, "missing file: " + expectedOutputFile)
+        self.assertTrue(len(manifest) > 0, "missing manifest file ")
 
     def doConversionForRepo(self, baseUrl, user, repo):
         build_log_json = None

--- a/tests/integration_tests/test_conversion.py
+++ b/tests/integration_tests/test_conversion.py
@@ -57,7 +57,7 @@ class TestConversions(TestCase):
     def test_usfm_mat_conversion(self):
         # given
         if not self.isTestingEnabled(): return # skip test if integration test not enabled
-        git_url = "https://git.door43.org/vedhanthavijay/kpb_mat_text_udb.git"
+        git_url = "https://git.door43.org/tx-manager-test-data/kpb_mat_text_udb.git"
         baseUrl, repo, user = self.getPartsOfGitUrl(git_url)
         expectedOutputName = "41-MAT"
 
@@ -71,7 +71,7 @@ class TestConversions(TestCase):
     def test_usfm_acts0_conversion(self):
         # given
         if not self.isTestingEnabled(): return # skip test if integration test not enabled
-        git_url = "https://git.door43.org/lversaw/awa_act_text_reg.git"
+        git_url = "https://git.door43.org/tx-manager-test-data/awa_act_text_reg.git"
         baseUrl, repo, user = self.getPartsOfGitUrl(git_url)
         expectedOutputName = "45-ACT"
 
@@ -94,10 +94,131 @@ class TestConversions(TestCase):
         # then
         self.validateConversion(user, repo, success, build_log_json, commitID, commitSha, commitPath, "", job, chapterCount=expectedChapterCount, fileExt="md")
 
-    def test_usfm_acts1_conversion(self):
+    def test_obs_conversion_ts_upload(self):
         # given
         if not self.isTestingEnabled(): return # skip test if integration test not enabled
-        git_url = "https://git.door43.org/deva/kan-x-aruvu_act_text_udb.git"
+        git_url = "https://git.door43.org/tx-manager-test-data/hu_obs_text_obs.git"
+        baseUrl, repo, user = self.getPartsOfGitUrl(git_url)
+        expectedChapterCount = 49
+
+        # when
+        build_log_json, commitID, commitPath, commitSha, success, job = self.doConversionForRepo(baseUrl, user, repo)
+
+        # then
+        self.validateConversion(user, repo, success, build_log_json, commitID, commitSha, commitPath, "", job, chapterCount=expectedChapterCount, fileExt="md")
+
+    def test_usfm_en_jud_bundle_conversion(self):
+        # given
+        if not self.isTestingEnabled(): return # skip test if integration test not enabled
+        git_url = "https://git.door43.org/tx-manager-test-data/en-ulb-jud.git"
+        baseUrl, repo, user = self.getPartsOfGitUrl(git_url)
+        expectedOutputNames = [ "66-JUD" ]
+
+        # when
+        build_log_json, commitID, commitPath, commitSha, success, job = self.doConversionForRepo(baseUrl, user, repo)
+
+        # then
+        self.validateConversion(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputNames, job)
+
+    @unittest.skip("Skipping broken conversion that needs to be fixed - conversion takes too long and times out")
+    def test_usfm_en_bundle_conversion(self):
+        # given
+        if not self.isTestingEnabled(): return # skip test if integration test not enabled
+        git_url = "https://git.door43.org/tx-manager-test-data/en-ulb.git"
+        baseUrl, repo, user = self.getPartsOfGitUrl(git_url)
+        expectedOutputNames = [ "01-GEN", "02-EXO", "03-LEV", "05-DEU" ]
+
+        # when
+        build_log_json, commitID, commitPath, commitSha, success, job = self.doConversionForRepo(baseUrl, user, repo)
+
+        # then
+        self.validateConversion(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputNames, job)
+
+    @unittest.skip("Skipping broken conversion that needs to be fixed - conversion takes too long and times out")
+    def test_usfm_ru_bundle_conversion(self):
+        # given
+        if not self.isTestingEnabled(): return # skip test if integration test not enabled
+        git_url = "https://git.door43.org/tx-manager-test-data/bible_ru.git"
+        baseUrl, repo, user = self.getPartsOfGitUrl(git_url)
+        expectedOutputNames = [
+            "01-GEN",
+            "02-EXO",
+            "03-LEV",
+            "04-NUM",
+            "05-DEU",
+            "06-JOS",
+            "07-JDG",
+            "08-RUT",
+            "09-1SA",
+            "10-2SA",
+            "11-1KI",
+            "12-2KI",
+            "13-1CH",
+            "14-2CH",
+            "15-EZR",
+            "16-NEH",
+            "17-EST",
+            "18-JOB",
+            "19-PSA",
+            "20-PRO",
+            "21-ECC",
+            "22-SNG",
+            "23-ISA",
+            "24-JER",
+            "25-LAM",
+            "26-EZK",
+            "27-DAN",
+            "28-HOS",
+            "29-JOL",
+            "30-AMO",
+            "31-OBA",
+            "32-JON",
+            "33-MIC",
+            "34-NAM",
+            "35-HAB",
+            "36-ZEP",
+            "37-HAG",
+            "38-ZEC",
+            "39-MAL",
+            "41-MAT",
+            "42-MRK",
+            "43-LUK",
+            "44-JHN",
+            "45-ACT",
+            "46-ROM",
+            "47-1CO",
+            "48-2CO",
+            "49-GAL",
+            "50-EPH",
+            "51-PHP",
+            "52-COL",
+            "53-1TH",
+            "54-2TH",
+            "55-1TI",
+            "56-2TI",
+            "57-TIT",
+            "58-PHM",
+            "59-HEB",
+            "60-JAS",
+            "61-1PE",
+            "62-2PE",
+            "63-1JN",
+            "64-2JN",
+            "65-3JN",
+            "66-JUD",
+            "67-REV"
+        ]
+
+        # when
+        build_log_json, commitID, commitPath, commitSha, success, job = self.doConversionForRepo(baseUrl, user, repo)
+
+        # then
+        self.validateConversion(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputNames, job)
+
+    def test_ts_acts1_conversion(self):
+        # given
+        if not self.isTestingEnabled(): return # skip test if integration test not enabled
+        git_url = "https://git.door43.org/tx-manager-test-data/kan-x-aruvu_act_text_udb.git"
         baseUrl, repo, user = self.getPartsOfGitUrl(git_url)
         expectedOutputName = "45-ACT"
 
@@ -107,7 +228,7 @@ class TestConversions(TestCase):
         # then
         self.validateConversion(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
 
-    def test_usfm_acts2_conversion(self):
+    def test_ts_acts2_conversion(self):
         # given
         if not self.isTestingEnabled(): return # skip test if integration test not enabled
         git_url = "https://git.door43.org/mohanraj/kn-x-bedar_act_text_udb.git"
@@ -121,7 +242,7 @@ class TestConversions(TestCase):
         self.validateConversion(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
 
     @unittest.skip("Skip test for time reasons - leave for standalone testing")
-    def test_usfm_acts3_conversion(self):
+    def test_ts_acts3_conversion(self):
         # given
         if not self.isTestingEnabled(): return # skip test if integration test not enabled
         git_url = "https://git.door43.org/nirmala/te-x-budugaja_act_text_reg.git"
@@ -135,7 +256,7 @@ class TestConversions(TestCase):
         self.validateConversion(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
 
     @unittest.skip("Skip test for time reasons - leave for standalone testing")
-    def test_usfm_acts4_conversion(self):
+    def test_ts_acts4_conversion(self):
         # given
         if not self.isTestingEnabled(): return # skip test if integration test not enabled
         git_url = "https://git.door43.org/jathapu/kxv_act_text_udb.git"
@@ -149,7 +270,7 @@ class TestConversions(TestCase):
         self.validateConversion(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
 
     @unittest.skip("Skip test for time reasons - leave for standalone testing")
-    def test_usfm_acts5_conversion(self):
+    def test_ts_acts5_conversion(self):
         # given
         if not self.isTestingEnabled(): return # skip test if integration test not enabled
         git_url = "https://git.door43.org/vinaykumar/kan-x-thigularu_act_text_udb.git"
@@ -163,7 +284,7 @@ class TestConversions(TestCase):
         self.validateConversion(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
 
     @unittest.skip("Skip test for time reasons - leave for standalone testing")
-    def test_usfm_acts6_conversion(self):
+    def test_ts_acts6_conversion(self):
         # given
         if not self.isTestingEnabled(): return # skip test if integration test not enabled
         git_url = "https://git.door43.org/Zipson/yeu_act_text_udb.git"
@@ -177,7 +298,7 @@ class TestConversions(TestCase):
         self.validateConversion(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
 
     @unittest.skip("Skip test for time reasons - leave for standalone testing")
-    def test_usfm_acts7_conversion(self):
+    def test_ts_acts7_conversion(self):
         # given
         if not self.isTestingEnabled(): return # skip test if integration test not enabled
         git_url = "https://git.door43.org/Zipson/kfc_act_text_udb.git"
@@ -191,7 +312,7 @@ class TestConversions(TestCase):
         self.validateConversion(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
 
     @unittest.skip("Skip test for time reasons - leave for standalone testing")
-    def test_usfm_acts8_conversion(self):
+    def test_ts_acts8_conversion(self):
         # given
         if not self.isTestingEnabled(): return # skip test if integration test not enabled
         git_url = "https://git.door43.org/E01877C8393A/uw-act_udb-aen.git"
@@ -226,18 +347,21 @@ class TestConversions(TestCase):
         repo = parts[4].split(".git")[0]
         return baseUrl, repo, user
 
-    def validateConversion(self, user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job, chapterCount=-1, fileExt=""):
+    def validateConversion(self, user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputNames, job, chapterCount=-1, fileExt=""):
         self.assertTrue(len(build_log_json) > 0)
         self.assertIsNotNone(job)
         self.temp_dir = tempfile.mkdtemp(prefix='testing_')
 
+        if not (type(expectedOutputNames) is list):
+            expectedOutputNames = [ expectedOutputNames ] # put string in list
+
         # check pre-convert files
-        self.downloadAndCheckZipFile(self.s3_handler, expectedOutputName + ".usfm", self.getPreconvertS3Key(commitSha),
-                                     "preconvert", success, chapterCount, fileExt)
+        self.downloadAndCheckZipFile(self.s3_handler, expectedOutputNames, "usfm", self.getPreconvertS3Key(commitSha),
+                                         "preconvert", success, chapterCount, fileExt)
 
         # check deployed files
-        self.checkDestinationFiles(self.cdn_handler, expectedOutputName + ".html",
-                                   self.getDestinationS3Key(commitSha, repo, user), chapterCount)
+        self.checkDestinationFiles(self.cdn_handler, expectedOutputNames, "html",
+                                        self.getDestinationS3Key(commitSha, repo, user), chapterCount)
 
         self.assertEqual(len(commitID), COMMIT_LENGTH)
         self.assertIsNotNone(commitSha)
@@ -246,7 +370,7 @@ class TestConversions(TestCase):
         self.assertTrue(len(build_log_json['errors']) == 0, "Found build_log errors: " + str(build_log_json['errors']))
         self.assertTrue(success)
 
-    def downloadAndCheckZipFile(self, handler, expectedOutputFile, key, type, success, chapterCount=-1, fileExt=""):
+    def downloadAndCheckZipFile(self, handler, expectedOutputFiles, extension, key, type, success, chapterCount=-1, fileExt=""):
         zipPath = os.path.join(self.temp_dir, type + ".zip")
         handler.download_file(key, zipPath)
         temp_sub_dir = tempfile.mkdtemp(dir=self.temp_dir, prefix=type + "_")
@@ -254,7 +378,8 @@ class TestConversions(TestCase):
 
         checkList = []
         if chapterCount <= 0:
-            checkList.append(expectedOutputFile)
+            for file in expectedOutputFiles:
+                checkList.append(file + "." + extension)
         else:
             checkList = ['{0:0>2}.{1}'.format(i, fileExt) for i in range(1, chapterCount + 1)]
 
@@ -282,10 +407,11 @@ class TestConversions(TestCase):
         text = file_utils.read_file(filePath)
         print("Output file (" + fileName + "): " + text)
 
-    def checkDestinationFiles(self, handler, expectedOutputFile, key, chapterCount=-1):
+    def checkDestinationFiles(self, handler, expectedOutputFiles, extension, key, chapterCount=-1):
         checkList = []
         if chapterCount <= 0:
-            checkList.append(expectedOutputFile)
+            for file in expectedOutputFiles:
+                checkList.append(file + "." + extension)
         else:
             checkList = ['{0:0>2}.html'.format(i) for i in range(1, chapterCount + 1)]
             # checkList.append("index.html")
@@ -394,9 +520,14 @@ class TestConversions(TestCase):
         except Exception as e:
             message = "Exception: " + str(e)
             print(message)
-            return None, False
+            return None, False, None
 
-        success, job = self.pollUntilJobFinished(build_log_json['job_id'])
+        job_id = build_log_json['job_id']
+        if job_id == None:
+            print("Job ID missing in build_log")
+            return None, False, None
+
+        success, job = self.pollUntilJobFinished(job_id)
         build_log_json = self.getJsonFile(commitSha, 'build_log.json', repo, user)
         if build_log_json != None:
             print("Final results:\n" + str(build_log_json))

--- a/tests/integration_tests/test_conversion.py
+++ b/tests/integration_tests/test_conversion.py
@@ -1,0 +1,76 @@
+# coding=utf-8
+from __future__ import absolute_import, unicode_literals
+
+import os
+from unittest import TestCase
+
+import requests
+from bs4 import BeautifulSoup
+
+
+class TestConversions(TestCase):
+
+    def test_usfm_bundle(self):
+        baseUrl = "https://git.door43.org"
+        user = "deva"
+        repo = "kan-x-aruvu_act_text_udb"
+
+        commitID, commitPath, commitSha = self.fetchCommitDataForRepo(baseUrl, repo, user)
+
+        self.assertIsNotNone(commitID)
+        self.assertIsNotNone(commitSha)
+        self.assertIsNotNone(commitPath)
+
+        print("Loaded: " + self.url)
+
+    def fetchCommitDataForRepo(self, baseUrl, repo, user):
+        commitID = None
+        commitSha = None
+        commitPath = None
+        data = self.readContentsOfRepo(baseUrl, user, repo)
+        if len(data) > 10:
+            commitID, commitSha, commitPath = self.findLastedCommitFromPage(data)
+        return commitID, commitPath, commitSha
+
+    def findLastedCommitFromPage(self, text):
+        soup = BeautifulSoup(text, 'html.parser')
+        table = soup.find('table')
+        commitID = None
+        commitSha = None
+        commitPath = None
+        if table != None:
+            rows = table.findAll('tr')
+            if (rows != None) and (len(rows) > 0):
+                for row in rows:
+                    commitCell = row.find('td', {"class": "sha"} )
+                    if commitCell != None:
+                        commitLink = commitCell.find('a')
+                        if commitLink != None:
+                            commitPath = commitLink['href']
+                            commitSha = self.getContents(commitLink)
+                            parts = commitPath.split('/')
+                            commitID = parts[4];
+                            break
+
+        return commitID, commitSha, commitPath
+
+    def makeFolder(self, directory):
+        if not os.path.exists(directory):
+            os.makedirs(directory)
+
+    def readContentsOfRepo(self, baseUrl, user, repo):
+        self.url = "{0}/{1}/{2}/commits/master".format(baseUrl, user, repo)
+        ttr_response = requests.get(self.url)
+        if ttr_response.status_code == 200:
+            return ttr_response.text
+
+        print("Failed to load: " + self.url)
+        return None
+
+    def getContents(self, item):
+        if item != None:
+            contents = item.stripped_strings
+            for string in contents:
+                text = string
+                return text
+        return None

--- a/tests/integration_tests/test_conversion.py
+++ b/tests/integration_tests/test_conversion.py
@@ -5,19 +5,60 @@ import os
 from unittest import TestCase
 
 import requests
+from client.client_webhook import ClientWebhook
+
 from bs4 import BeautifulSoup
 
+COMMIT_LENGTH = 40
 
 class TestConversions(TestCase):
 
     def test_usfm_bundle(self):
+        
         baseUrl = "https://git.door43.org"
         user = "deva"
         repo = "kan-x-aruvu_act_text_udb"
 
         commitID, commitPath, commitSha = self.fetchCommitDataForRepo(baseUrl, repo, user)
+        commitLen = len(commitID)
+        if commitLen == COMMIT_LENGTH:
+            webhookData = {
+                "after": commitID,
+                "commits": [
+                    {
+                        "id": "b9278437b27024e07d02490400138d4fd7d1677c",
+                        "message": "Fri Dec 16 2016 11:09:07 GMT+0530 (India Standard Time)\n",
+                        "url": baseUrl + commitPath,
+                    }],
+                "compare_url": "",
+                "repository": {
+                    "name": repo,
+                    "owner": {
+                        "id": 1234567890,
+                        "username": user,
+                        "full_name": user,
+                        "email": "you@example.com"
+                    },
+                },
+                "pusher": {
+                    "id": 123456789,
+                    "username": "test",
+                    "full_name": "",
+                    "email": "you@example.com"
+                },
+            }
+            env_vars = {
+                'api_url': 'https://test-api.door43.org',
+                'pre_convert_bucket': 'test-tx-webhook-client',
+                'cdn_bucket': 'test-cdn.door43.org',
+                'gogs_url': 'https://git.door43.org',
+                'gogs_user_token': 'token1',
+                'commit_data': webhookData
+            }
+            retVal = ClientWebhook(**env_vars).process_webhook()
+            pass
 
-        self.assertIsNotNone(commitID)
+        self.assertEqual(commitLen, COMMIT_LENGTH)
         self.assertIsNotNone(commitSha)
         self.assertIsNotNone(commitPath)
 

--- a/tests/integration_tests/test_conversion.py
+++ b/tests/integration_tests/test_conversion.py
@@ -11,6 +11,8 @@ import shutil
 
 import time
 
+from manager.manager import TxManager
+
 from general_tools.file_utils import unzip
 
 from aws_tools.s3_handler import S3Handler
@@ -23,11 +25,66 @@ COMMIT_LENGTH = 40
 
 class TestConversions(TestCase):
 
+    def setUp(self):
+        self.api_url = 'https://dev-api.door43.org'
+        self.pre_convert_bucket = 'dev-tx-webhook-client'
+        self.gogs_url = 'https://git.door43.org'
+        self.cdn_bucket = 'dev-cdn.door43.org'
+        self.job_table_name = 'dev-tx-job'
+        self.module_table_name = 'dev-tx-module'
+        self.cdn_url = 'https://dev-cdn.door43.org'
+
     def tearDown(self):
         """Runs after each test."""
         # delete temp files
         if hasattr(self, 'temp_dir') and os.path.isdir(self.temp_dir):
             shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_usfm_mat_bundle(self):
+        # given
+        if not self.doWeWantToRunTest(): return # skip test if integration test not enabled
+        baseUrl = "https://git.door43.org"
+        user = "vedhanthavijay"
+        repo = "kpb_mat_text_udb"
+        expectedOutputName = "41-MAT"
+
+        # when
+        build_log_json, commitID, commitPath, commitSha, success = self.doConversionForRepo(baseUrl, user, repo)
+
+        # then
+        self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName)
+
+    def test_usfm_acts_bundle(self):
+        # given
+        if not self.doWeWantToRunTest(): return # skip test if integration test not enabled
+        baseUrl = "https://git.door43.org"
+        user = "lversaw"
+        repo = "awa_act_text_reg"
+        expectedOutputName = "45-ACT"
+
+        # when
+        build_log_json, commitID, commitPath, commitSha, success = self.doConversionForRepo(baseUrl, user, repo)
+
+        # then
+        self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName)
+
+    def test_usfm_acts2_bundle(self):
+        # given
+        if not self.doWeWantToRunTest(): return # skip test if integration test not enabled
+        baseUrl = "https://git.door43.org"
+        user = "deva"
+        repo = "kan-x-aruvu_act_text_udb"
+        expectedOutputName = "45-ACT"
+
+        # when
+        build_log_json, commitID, commitPath, commitSha, success = self.doConversionForRepo(baseUrl, user, repo)
+
+        # then
+        self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName)
+
+    ##
+    ## handlers
+    ##
 
     def doWeWantToRunTest(self):
         test = os.environ.get('TEST_DEPLOYED',"")
@@ -39,42 +96,20 @@ class TestConversions(TestCase):
             self.assertTrue(len(gogsUserToken) > 0, "GOGS_USER_TOKEN is missing in environment")
         return doTest
 
-    def test_usfm_bundle(self):
-        if not self.doWeWantToRunTest():
-            return # skip test if not running master branch
-
-        # given
-        self.api_url = 'https://dev-api.door43.org'
-        self.pre_convert_bucket = 'dev-tx-webhook-client'
-        self.gogs_url = 'https://git.door43.org'
-        self.cdn_bucket = 'dev-cdn.door43.org'
-        baseUrl = "https://git.door43.org"
-        user = "deva"
-        repo = "kan-x-aruvu_act_text_udb"
-        expectedOutputName = "45-ACT"
-
-        # when
-        build_log_json, commitID, commitPath, commitSha, success = self.doConversionForRepo(baseUrl, user, repo)
-
-        # then
+    def validateBible(self, user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName):
         self.assertTrue(len(build_log_json) > 0)
         self.assertTrue(len(build_log_json['errors']) == 0, "Found errors: " + str(build_log_json['errors']))
         self.assertTrue(success)
-
         self.temp_dir = tempfile.mkdtemp(prefix='testing_')
         self.downloadAndCheckZipFile(self.s3_handler, expectedOutputName + ".usfm", self.getPreconvertS3Key(commitSha),
                                      "preconvert")
-
         # this gets deleted after conversion:
         # self.downloadAndCheckZipFile(self.cdn_handler, expectedOutputName + ".html", self.getTxOutputS3Key(commitID), "output")
-
-        self.checkDestinationFiles(self.cdn_handler, expectedOutputName + ".html", self.getDestinationS3Key(commitSha, repo, user))
-
+        self.checkDestinationFiles(self.cdn_handler, expectedOutputName + ".html",
+                                   self.getDestinationS3Key(commitSha, repo, user))
         self.assertEqual(len(commitID), COMMIT_LENGTH)
         self.assertIsNotNone(commitSha)
         self.assertIsNotNone(commitPath)
-
-    ## handlers
 
     def downloadAndCheckZipFile(self, handler, expectedOutputFile, key, type):
         zipPath = os.path.join(self.temp_dir, type + ".zip")
@@ -127,8 +162,8 @@ class TestConversions(TestCase):
             self.cdn_handler.delete_file(txOutput_key, catch_exception=True)
 
     def getTxOutputS3Key(self, commitID):
-        destination_key = 'tx/job/{0}.zip'.format(commitID)
-        return destination_key
+        output_key = 'tx/job/{0}.zip'.format(commitID)
+        return output_key
 
     def getDestinationS3Key(self, commitSha, repo, user):
         destination_key = 'u/{0}/{1}/{2}'.format(user, repo, commitSha)
@@ -177,35 +212,55 @@ class TestConversions(TestCase):
             'commit_data': webhookData
         }
         try:
-            ClientWebhook(**env_vars).process_webhook()
+            build_log_json = ClientWebhook(**env_vars).process_webhook()
         except Exception as e:
             message = "Exception: " + str(e)
             print(message)
             return None, False
 
-        build_log_json, success = self.pollUntilJobFinished(commitSha, repo, user)
-        return build_log_json, success
-
-    def pollUntilJobFinished(self, commitSha, repo, user):
-        build_log_json = None
-        success = False
-        pollingTimeout = 5 * 60 # poll for up to 5 minutes for job to complete or error
-        sleepInterval = 5 # how often to check for completion
-        for i in range(0, pollingTimeout / sleepInterval):
-            build_log_json = self.getJsonFile(commitSha, 'build_log.json', repo, user)
-            self.assertTrue(len(build_log_json) > 0)
-            if len(build_log_json['errors']) > 0:
-                print("Found errors: " + str(build_log_json['errors']))
-                break
-            if build_log_json['ended_at'] != None:
-                success = True
-                break
-            print("status at " + str(i) + ":\n" + str(build_log_json))
-            time.sleep(sleepInterval)
-
+        success = self.pollUntilJobFinished(build_log_json['job_id'])
+        build_log_json = self.getJsonFile(commitSha, 'build_log.json', repo, user)
         if build_log_json != None:
             print("Final results:\n" + str(build_log_json))
         return build_log_json, success
+
+    def pollUntilJobFinished(self, job_id):
+        success = False
+
+        env_vars = {
+            'api_url': self.api_url,
+            'gogs_url': self.gogs_url,
+            'cdn_url': self.cdn_url,
+            'job_table_name':  self.job_table_name,
+            'module_table_name': self.module_table_name,
+            'cdn_bucket': self.cdn_bucket
+        }
+        tx_manager = TxManager(**env_vars)
+
+        pollingTimeout = 5 * 60 # poll for up to 5 minutes for job to complete or error
+        sleepInterval = 5 # how often to check for completion
+        startMaxWaitCount = 30 / sleepInterval # maximum count to wait for conversion to start (sec/interval)
+        for i in range(0, pollingTimeout / sleepInterval):
+            job = tx_manager.get_job(job_id)
+            self.assertIsNotNone(job)
+            print("job status at " + str(i) + ":\n" + str(job.log))
+
+            if len(job.errors) > 0:
+                print("Found errors: " + str(job.errors))
+                break
+
+            if job.ended_at != None:
+                success = True
+                break
+
+            if (i > startMaxWaitCount) and (job.started_at == None):
+                success = False
+                print("Conversion Failed to start")
+                break
+
+            time.sleep(sleepInterval)
+
+        return success
 
     def getJsonFile(self, commitSha, file, repo, user):
         key = 'u/{0}/{1}/{2}/{3}'.format(user, repo, commitSha, file)

--- a/tests/integration_tests/test_conversion.py
+++ b/tests/integration_tests/test_conversion.py
@@ -1,10 +1,18 @@
 # coding=utf-8
 from __future__ import absolute_import, unicode_literals
 
+import tempfile
+
 import os
 from unittest import TestCase
 
 import requests
+import shutil
+
+import time
+
+from aws_tools.s3_handler import S3Handler
+
 from client.client_webhook import ClientWebhook
 
 from bs4 import BeautifulSoup
@@ -13,56 +21,126 @@ COMMIT_LENGTH = 40
 
 class TestConversions(TestCase):
 
+    def tearDown(self):
+        """Runs after each test."""
+        # delete temp files
+        if hasattr(self, 'temp_dir') and os.path.isdir(self.temp_dir):
+            shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def doWeWantToRunTest(self):
+        branch = os.environ.get('TRAVIS_BRANCH',"")
+        if branch == "": # if Travis variable is not set, then default to master for local testing
+            branch = "master"
+            print("Doing Local Testing")
+
+        doTest = (branch == "master")
+        if not doTest:
+            print("Skip testing since not running in master branch but branch: " + branch)
+        else:
+            gogsUserToken = os.environ.get('GOGS_USER_TOKEN',"")
+            self.assertTrue(len(gogsUserToken) > 0, "GOGS_USER_TOKEN is missing in environment")
+        return doTest
+
     def test_usfm_bundle(self):
-        
+        if not self.doWeWantToRunTest():
+            return # skip test if not running master branch
+
+        # given
         baseUrl = "https://git.door43.org"
         user = "deva"
         repo = "kan-x-aruvu_act_text_udb"
 
-        commitID, commitPath, commitSha = self.fetchCommitDataForRepo(baseUrl, repo, user)
-        commitLen = len(commitID)
-        if commitLen == COMMIT_LENGTH:
-            webhookData = {
-                "after": commitID,
-                "commits": [
-                    {
-                        "id": "b9278437b27024e07d02490400138d4fd7d1677c",
-                        "message": "Fri Dec 16 2016 11:09:07 GMT+0530 (India Standard Time)\n",
-                        "url": baseUrl + commitPath,
-                    }],
-                "compare_url": "",
-                "repository": {
-                    "name": repo,
-                    "owner": {
-                        "id": 1234567890,
-                        "username": user,
-                        "full_name": user,
-                        "email": "you@example.com"
-                    },
-                },
-                "pusher": {
-                    "id": 123456789,
-                    "username": "test",
-                    "full_name": "",
-                    "email": "you@example.com"
-                },
-            }
-            env_vars = {
-                'api_url': 'https://test-api.door43.org',
-                'pre_convert_bucket': 'test-tx-webhook-client',
-                'cdn_bucket': 'test-cdn.door43.org',
-                'gogs_url': 'https://git.door43.org',
-                'gogs_user_token': 'token1',
-                'commit_data': webhookData
-            }
-            retVal = ClientWebhook(**env_vars).process_webhook()
-            pass
+        # when
+        build_log_json, commitID, commitPath, commitSha, success = self.doConversionForRepo(baseUrl, user, repo)
 
-        self.assertEqual(commitLen, COMMIT_LENGTH)
+        # then
+        self.assertTrue(len(build_log_json) > 0)
+        self.assertTrue(len(build_log_json['errors']) == 0, "Found errors: " + str(build_log_json['errors']))
+        self.assertTrue(success)
+        self.assertEqual(len(commitID), COMMIT_LENGTH)
         self.assertIsNotNone(commitSha)
         self.assertIsNotNone(commitPath)
 
-        print("Loaded: " + self.url)
+    ## handlers
+
+    def doConversionForRepo(self, baseUrl, user, repo):
+        commitID, commitPath, commitSha = self.fetchCommitDataForRepo(baseUrl, repo, user)  # TODO: change this to use gogs API when finished
+        commitLen = len(commitID)
+        if commitLen == COMMIT_LENGTH:
+            build_log_json, success = self.doConversionJob(baseUrl, commitID, commitPath, commitSha, repo, user)
+        return build_log_json, commitID, commitPath, commitSha, success
+
+    def doConversionJob(self, baseUrl, commitID, commitPath, commitSha, repo, user):
+        gogsUserToken = os.environ.get('GOGS_USER_TOKEN',"")
+        if len(gogsUserToken) == 0:
+            print("GOGS_USER_TOKEN is missing in environment")
+
+        webhookData = {
+            "after": commitID,
+            "commits": [
+                {
+                    "id": "b9278437b27024e07d02490400138d4fd7d1677c",
+                    "message": "Fri Dec 16 2016 11:09:07 GMT+0530 (India Standard Time)\n",
+                    "url": baseUrl + commitPath,
+                }],
+            "compare_url": "",
+            "repository": {
+                "name": repo,
+                "owner": {
+                    "id": 1234567890,
+                    "username": user,
+                    "full_name": user,
+                    "email": "you@example.com"
+                },
+            },
+            "pusher": {
+                "id": 123456789,
+                "username": "test",
+                "full_name": "",
+                "email": "you@example.com"
+            },
+        }
+        env_vars = {
+            'api_url': 'https://dev-api.door43.org',
+            'pre_convert_bucket': 'dev-tx-webhook-client',
+            'cdn_bucket': 'dev-cdn.door43.org',
+            'gogs_url': 'https://git.door43.org',
+            'gogs_user_token': gogsUserToken,
+            'commit_data': webhookData
+        }
+        try:
+            success = False
+            cdn_handler = S3Handler(env_vars['cdn_bucket'])
+            ClientWebhook(**env_vars).process_webhook()
+        except Exception as e:
+            message = "Exception: " + str(e)
+            print(message)
+            return None, False
+
+        build_log_json, success = self.pollUntilJobFinished(cdn_handler, commitSha, repo, success, user)
+        return build_log_json, success
+
+    def pollUntilJobFinished(self, cdn_handler, commitSha, repo, success, user):
+        for i in range(0, 60):  # poll for up to 300 seconds for job to complete or error
+            build_log_json = self.getJsonFile(cdn_handler, commitSha, 'build_log.json', repo, user)
+            self.assertTrue(len(build_log_json) > 0)
+            if len(build_log_json['errors']) > 0:
+                print("Found errors: " + str(build_log_json['errors']))
+                break
+            if build_log_json['ended_at'] != None:
+                success = True
+                break
+            print("status at " + str(i) + ":\n" + str(build_log_json))
+            time.sleep(5)
+
+        if build_log_json != None:
+            print("Final results:\n" + str(build_log_json))
+        return build_log_json, success
+
+    def getJsonFile(self, cdn_handler, commitSha, file, repo, user):
+        key = 'u/{0}/{1}/{2}/{3}'.format(user, repo, commitSha, file)
+        text = cdn_handler.get_json(key)
+        return text
 
     def fetchCommitDataForRepo(self, baseUrl, repo, user):
         commitID = None

--- a/tests/integration_tests/test_conversion.py
+++ b/tests/integration_tests/test_conversion.py
@@ -48,7 +48,34 @@ class TestConversions(TestCase):
         build_log_json, commitID, commitPath, commitSha, success, job = self.doConversionForRepo(baseUrl, user, repo)
 
         # then
-        self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
+        self.validateConversion(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
+
+    @unittest.skip("Needs to be fixed - Expected end of text (at char 24993), (line:292, col:121) backslash in text")
+    def test_usfm_acts0_conversion(self):
+        # given
+        if not self.doWeWantToRunTest(): return # skip test if integration test not enabled
+        git_url = "https://git.door43.org/lversaw/awa_act_text_reg.git"
+        baseUrl, repo, user = self.getPartsOfGitUrl(git_url)
+        expectedOutputName = "45-ACT"
+
+        # when
+        build_log_json, commitID, commitPath, commitSha, success, job = self.doConversionForRepo(baseUrl, user, repo)
+
+        # then
+        self.validateConversion(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
+
+    def test_obs_conversion(self):
+        # given
+        if not self.doWeWantToRunTest(): return # skip test if integration test not enabled
+        git_url = "https://git.door43.org/tx-manager-test-data/en-obs-rc-0.2.git"
+        baseUrl, repo, user = self.getPartsOfGitUrl(git_url)
+        expectedChapterCount = 50
+
+        # when
+        build_log_json, commitID, commitPath, commitSha, success, job = self.doConversionForRepo(baseUrl, user, repo)
+
+        # then
+        self.validateConversion(user, repo, success, build_log_json, commitID, commitSha, commitPath, "", job, chapterCount=expectedChapterCount)
 
     def test_usfm_acts1_conversion(self):
         # given
@@ -61,7 +88,7 @@ class TestConversions(TestCase):
         build_log_json, commitID, commitPath, commitSha, success, job = self.doConversionForRepo(baseUrl, user, repo)
 
         # then
-        self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
+        self.validateConversion(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
 
     def test_usfm_acts2_conversion(self):
         # given
@@ -74,7 +101,7 @@ class TestConversions(TestCase):
         build_log_json, commitID, commitPath, commitSha, success, job = self.doConversionForRepo(baseUrl, user, repo)
 
         # then
-        self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
+        self.validateConversion(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
 
     def test_usfm_acts3_conversion(self):
         # given
@@ -87,7 +114,7 @@ class TestConversions(TestCase):
         build_log_json, commitID, commitPath, commitSha, success, job = self.doConversionForRepo(baseUrl, user, repo)
 
         # then
-        self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
+        self.validateConversion(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
 
     def test_usfm_acts4_conversion(self):
         # given
@@ -100,7 +127,7 @@ class TestConversions(TestCase):
         build_log_json, commitID, commitPath, commitSha, success, job = self.doConversionForRepo(baseUrl, user, repo)
 
         # then
-        self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
+        self.validateConversion(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
 
     def test_usfm_acts5_conversion(self):
         # given
@@ -113,7 +140,7 @@ class TestConversions(TestCase):
         build_log_json, commitID, commitPath, commitSha, success, job = self.doConversionForRepo(baseUrl, user, repo)
 
         # then
-        self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
+        self.validateConversion(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
 
     def test_usfm_acts6_conversion(self):
         # given
@@ -126,9 +153,8 @@ class TestConversions(TestCase):
         build_log_json, commitID, commitPath, commitSha, success, job = self.doConversionForRepo(baseUrl, user, repo)
 
         # then
-        self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
+        self.validateConversion(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
 
-    @unittest.skip("Needs to be fixed - doesn't generate output file")
     def test_usfm_acts7_conversion(self):
         # given
         if not self.doWeWantToRunTest(): return # skip test if integration test not enabled
@@ -140,7 +166,7 @@ class TestConversions(TestCase):
         build_log_json, commitID, commitPath, commitSha, success, job = self.doConversionForRepo(baseUrl, user, repo)
 
         # then
-        self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
+        self.validateConversion(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
 
     def test_usfm_acts8_conversion(self):
         # given
@@ -153,21 +179,7 @@ class TestConversions(TestCase):
         build_log_json, commitID, commitPath, commitSha, success, job = self.doConversionForRepo(baseUrl, user, repo)
 
         # then
-        self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
-
-    @unittest.skip("Needs to be fixed - Expected end of text (at char 24993), (line:292, col:121) backslash in text")
-    def test_usfm_acts9_conversion(self):
-        # given
-        if not self.doWeWantToRunTest(): return # skip test if integration test not enabled
-        git_url = "https://git.door43.org/lversaw/awa_act_text_reg.git"
-        baseUrl, repo, user = self.getPartsOfGitUrl(git_url)
-        expectedOutputName = "45-ACT"
-
-        # when
-        build_log_json, commitID, commitPath, commitSha, success, job = self.doConversionForRepo(baseUrl, user, repo)
-
-        # then
-        self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
+        self.validateConversion(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
 
     ##
     ## handlers
@@ -184,21 +196,26 @@ class TestConversions(TestCase):
         return doTest
 
     def getPartsOfGitUrl(self, git_url):
+        print("Testing conversion of: " + git_url)
         parts = git_url.split("/")
         baseUrl = "/".join(parts[0:3])
         user = parts[3]
-        repo = parts[4].split(".")[0]
+        repo = parts[4].split(".git")[0]
         return baseUrl, repo, user
 
-    def validateBible(self, user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job):
+    def validateConversion(self, user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job, chapterCount=-1):
         self.assertTrue(len(build_log_json) > 0)
         self.assertIsNotNone(job)
         self.temp_dir = tempfile.mkdtemp(prefix='testing_')
-        self.downloadAndCheckZipFile(self.s3_handler, expectedOutputName + ".usfm", self.getPreconvertS3Key(commitSha),
-                                     "preconvert", success)
 
+        # check pre-convert files
+        self.downloadAndCheckZipFile(self.s3_handler, expectedOutputName + ".usfm", self.getPreconvertS3Key(commitSha),
+                                     "preconvert", success, chapterCount)
+
+        # check deployed files
         self.checkDestinationFiles(self.cdn_handler, expectedOutputName + ".html",
-                                   self.getDestinationS3Key(commitSha, repo, user))
+                                   self.getDestinationS3Key(commitSha, repo, user), chapterCount)
+
         self.assertEqual(len(commitID), COMMIT_LENGTH)
         self.assertIsNotNone(commitSha)
         self.assertIsNotNone(commitPath)
@@ -206,14 +223,24 @@ class TestConversions(TestCase):
         self.assertTrue(len(build_log_json['errors']) == 0, "Found build_log errors: " + str(build_log_json['errors']))
         self.assertTrue(success)
 
-    def downloadAndCheckZipFile(self, handler, expectedOutputFile, key, type, success):
+    def downloadAndCheckZipFile(self, handler, expectedOutputFile, key, type, success, chapterCount=-1):
         zipPath = os.path.join(self.temp_dir, type + ".zip")
         handler.download_file(key, zipPath)
         temp_sub_dir = tempfile.mkdtemp(dir=self.temp_dir, prefix=type + "_")
         unzip(zipPath, temp_sub_dir)
-        outputFilePath = os.path.join(temp_sub_dir, expectedOutputFile)
-        self.assertTrue(os.path.exists(outputFilePath))
-        self.printFile(expectedOutputFile, outputFilePath)
+
+        checkList = []
+        if chapterCount <= 0:
+            checkList.append(expectedOutputFile)
+        else:
+            checkList = ['{0:0>2}.html'.format(i) for i in range(1, chapterCount + 1)]
+
+        for file in checkList:
+            outputFilePath = os.path.join(temp_sub_dir, file)
+            print("testing for: " + outputFilePath)
+            self.assertTrue(os.path.exists(outputFilePath), "missing file: " + file)
+            self.printFile(file, outputFilePath)
+
         manifest_json = os.path.join(temp_sub_dir, "manifest.json")
         json_exists = os.path.exists(manifest_json)
         if not success and json_exists: # print out for troubleshooting
@@ -223,17 +250,27 @@ class TestConversions(TestCase):
         if not success and yaml_exists:  # print out for troubleshooting
             self.printFile("manifest.yaml", manifest_yaml)
 
-        self.assertTrue(json_exists or yaml_exists)
+        self.assertTrue(json_exists or yaml_exists, "missing manifest file")
 
     def printFile(self, fileName, filePath):
         text = file_utils.read_file(filePath)
         print("Output file (" + fileName + "): " + text)
 
-    def checkDestinationFiles(self, handler, expectedOutputFile, key):
-        output = handler.get_file_contents(os.path.join(key, expectedOutputFile) )
-        if output==None: # try again in a moment since upload files may not be finished
-            time.sleep(5)
-            output = handler.get_file_contents(os.path.join(key, expectedOutputFile) )
+    def checkDestinationFiles(self, handler, expectedOutputFile, key, chapterCount=-1):
+        checkList = []
+        if chapterCount <= 0:
+            checkList.append(expectedOutputFile)
+        else:
+            checkList = ['{0:0>2}.html'.format(i) for i in range(1, chapterCount + 1)]
+
+        for file in checkList:
+            path = os.path.join(key, file)
+            print("testing for: " + path)
+            output = handler.get_file_contents(path)
+            if output==None: # try again in a moment since upload files may not be finished
+                time.sleep(5)
+                print("retry fetch of: " + path)
+                output = handler.get_file_contents(path)
 
         manifest = handler.get_file_contents(os.path.join(key, "manifest.json") )
         if manifest == None:

--- a/tests/integration_tests/test_conversion.py
+++ b/tests/integration_tests/test_conversion.py
@@ -56,7 +56,7 @@ class TestConversions(TestCase):
             shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     @unittest.skip("Skipping broken conversion that needs to be fixed - preconvert leaves backslash at end of line")
-    def test_usfm_mat_conversion(self):
+    def test_ts_mat_conversion(self):
         # given
         if not self.isTestingEnabled(): return # skip test if integration test not enabled
         git_url = "https://git.door43.org/tx-manager-test-data/kpb_mat_text_udb.git"
@@ -70,12 +70,25 @@ class TestConversions(TestCase):
         self.validateConversion(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
 
     @unittest.skip("Skipping broken conversion that needs to be fixed - Expected end of text (at char 24993), (line:292, col:121) backslash in text")
-    def test_usfm_acts0_conversion(self):
+    def test_ts_acts0_conversion(self):
         # given
         if not self.isTestingEnabled(): return # skip test if integration test not enabled
         git_url = "https://git.door43.org/tx-manager-test-data/awa_act_text_reg.git"
         baseUrl, repo, user = self.getPartsOfGitUrl(git_url)
         expectedOutputName = "45-ACT"
+
+        # when
+        build_log_json, commitID, commitPath, commitSha, success, job = self.doConversionForRepo(baseUrl, user, repo)
+
+        # then
+        self.validateConversion(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
+
+    def test_ts_psa_conversion(self):
+        # given
+        if not self.isTestingEnabled(): return # skip test if integration test not enabled
+        git_url = "https://git.door43.org/tx-manager-test-data/ceb_psa_text_ulb_L3.git"
+        baseUrl, repo, user = self.getPartsOfGitUrl(git_url)
+        expectedOutputName = "19-PSA"
 
         # when
         build_log_json, commitID, commitPath, commitSha, success, job = self.doConversionForRepo(baseUrl, user, repo)
@@ -359,11 +372,11 @@ class TestConversions(TestCase):
 
         # check pre-convert files
         self.downloadAndCheckZipFile(self.s3_handler, expectedOutputNames, "usfm", self.getPreconvertS3Key(commitSha),
-                                         "preconvert", success, chapterCount, fileExt)
+                                     "preconvert", success, chapterCount, fileExt)
 
         # check deployed files
         self.checkDestinationFiles(self.cdn_handler, expectedOutputNames, "html",
-                                        self.getDestinationS3Key(commitSha, repo, user), chapterCount)
+                                   self.getDestinationS3Key(commitSha, repo, user), chapterCount)
 
         self.assertEqual(len(commitID), COMMIT_LENGTH)
         self.assertIsNotNone(commitSha)
@@ -529,6 +542,7 @@ class TestConversions(TestCase):
             print(webhookData)
             response = requests.post(tx_client_webhook_url, json=webhookData, headers=headers)
             print('webhook finished with code:' + str(response.status_code))
+            print('webhook finished with text:' + str(response.text))
             build_log_json = json.loads(response.text)
             if response.status_code != 200:
                 return build_log_json, False, (build_log_json['job_id'])

--- a/tests/integration_tests/test_conversion.py
+++ b/tests/integration_tests/test_conversion.py
@@ -89,7 +89,7 @@ class TestConversions(TestCase):
         # then
         self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
 
-    def test_usfm_acts3_conversion(self):
+    def test_usfm_acts4_conversion(self):
         # given
         if not self.doWeWantToRunTest(): return # skip test if integration test not enabled
         git_url = "https://git.door43.org/jathapu/kxv_act_text_udb.git"
@@ -102,7 +102,7 @@ class TestConversions(TestCase):
         # then
         self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
 
-    def test_usfm_acts4_conversion(self):
+    def test_usfm_acts5_conversion(self):
         # given
         if not self.doWeWantToRunTest(): return # skip test if integration test not enabled
         git_url = "https://git.door43.org/vinaykumar/kan-x-thigularu_act_text_udb.git"
@@ -115,7 +115,7 @@ class TestConversions(TestCase):
         # then
         self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
 
-    def test_usfm_acts5_conversion(self):
+    def test_usfm_acts6_conversion(self):
         # given
         if not self.doWeWantToRunTest(): return # skip test if integration test not enabled
         git_url = "https://git.door43.org/Zipson/yeu_act_text_udb.git"
@@ -129,7 +129,7 @@ class TestConversions(TestCase):
         self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
 
     @unittest.skip("Needs to be fixed - doesn't generate output file")
-    def test_usfm_acts6_conversion(self):
+    def test_usfm_acts7_conversion(self):
         # given
         if not self.doWeWantToRunTest(): return # skip test if integration test not enabled
         git_url = "https://git.door43.org/Zipson/kfc_act_text_udb.git"
@@ -142,7 +142,7 @@ class TestConversions(TestCase):
         # then
         self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
 
-    def test_usfm_acts7_conversion(self):
+    def test_usfm_acts8_conversion(self):
         # given
         if not self.doWeWantToRunTest(): return # skip test if integration test not enabled
         git_url = "https://git.door43.org/E01877C8393A/uw-act_udb-aen.git"
@@ -156,7 +156,7 @@ class TestConversions(TestCase):
         self.validateBible(user, repo, success, build_log_json, commitID, commitSha, commitPath, expectedOutputName, job)
 
     @unittest.skip("Needs to be fixed - Expected end of text (at char 24993), (line:292, col:121) backslash in text")
-    def test_usfm_acts8_conversion(self):
+    def test_usfm_acts9_conversion(self):
         # given
         if not self.doWeWantToRunTest(): return # skip test if integration test not enabled
         git_url = "https://git.door43.org/lversaw/awa_act_text_reg.git"


### PR DESCRIPTION
Issues https://github.com/unfoldingWord-dev/door43.org/issues/417 and https://github.com/unfoldingWord-dev/door43.org/issues/416

Changes:
- added "integration_tests/test_conversion.py" that are only enabled when run from "integration_tests.sh".  Creates a psuedo webhook data and call webhook client. 
- .travis.yml - modified to run "integration_tests.sh" after deploy to validate tx-convert.
- clears out the preconvert zip and the cdn folder before testing. 
- Added checking of preconvert zip and output files after conversion.
